### PR TITLE
GoogleCloud terraform init

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,41 @@
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+credentials.json
+# End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.41.0"
+  constraints = "~> 5.41.0"
+  hashes = [
+    "h1:J41GybtL77Jk8f+CVnIQ5lR5wdY/uiOOABOXWlEc2qE=",
+    "zh:0c650a7f2291db37b961548d6e62beffe8d242ef35837a44a34833e7cee38196",
+    "zh:26a5620048708fb64bb357622584a3a9d0b300473929e575f2c1945247aadd14",
+    "zh:31b9b8412185716f87256036cc6dc762e7e1b2d36622122b40159225b5d428a8",
+    "zh:4c9d9d0c185a190ffad801772eca51f5d924d5044c7b16d156e65601eb7077c7",
+    "zh:4d93bd479f977689c09121b1ec2cf8fadd9511e9a9e78b1d73708cb67d43acfd",
+    "zh:60ca5275f555c4fdf521733d023792c8b6de121c1fc1628116c3f4be7c570cbb",
+    "zh:9bce12e395809ef0b569fb65064a9608841afbaad5c36017342a9a9ecd77f1c8",
+    "zh:a4cfae44d1e2e2e7c977460cabcf1fd8803bf2b4f567dfc957fbebf6863e7e94",
+    "zh:b3c583f549d1879ada90cce7a0c8598116a2c0d76c344daf3ea144811f34a961",
+    "zh:e21dcc534d0417051efd40633c4d308d1905fcf8d856297ee4dc57136f600245",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc755a262a5ffd6ce2d51155ab92d53f16b16aa290e2c63715abb4d133640f78",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.9.4, < 2.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.41.0"
+    }
+  }
+  backend "gcs" {
+    bucket = "mapstack-tfstate-backend"
+    prefix = "mapstack"
+  }
+}
+
+locals {
+  services = toset([
+    "run.googleapis.com",
+    "storage.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "service" {
+  for_each           = local.services
+  service            = each.value
+  disable_on_destroy = false
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = "mapstack-451909"
+  region  = "asia-northeast1"
+}

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,0 +1,4 @@
+resource "google_storage_bucket" "tfstate_backend" {
+  location = "asia-northeast1"
+  name     = "${var.project_name}-tfstate-backend"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "project_name" {
+  type    = string
+  default = "mapstack"
+}
+
+variable "project_id" {
+  type    = string
+  default = "mapstack-451909"
+}
+
+variable "region" {
+  type    = string
+  default = "asia-northeast1"
+}


### PR DESCRIPTION
This pull request introduces new Terraform configuration files to set up and manage Google Cloud resources. The most important changes include adding a `.gitignore` file for Terraform, defining the required providers and versions, configuring the Google Cloud provider, and setting up resources and variables.

Terraform configuration setup:

* [`terraform/.gitignore`](diffhunk://#diff-d819b47c9d1b5dac74644ad92a42826b3e571c3852ba9b5870510b7c4b927c74R1-R41): Added a `.gitignore` file to exclude Terraform-specific files and directories from version control.
* [`terraform/.terraform.lock.hcl`](diffhunk://#diff-845d0f38d4ba0c7d301f2a289b3d7304a7298455f93833c345fe398654b095baR1-R22): Added a lock file to specify the version and constraints for the Google provider.
* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R1-R28): Defined the required Terraform version, providers, backend configuration, and a local variable for Google Cloud services. Also added a resource to enable specific Google Cloud services.

Google Cloud provider configuration:

* [`terraform/provider.tf`](diffhunk://#diff-3136f4abdecb74a01476d52578a24f108e104076938c7c5f62ded9266d5b6d0cR1-R4): Configured the Google Cloud provider with the project ID and region.

Resource and variable definitions:

* [`terraform/state.tf`](diffhunk://#diff-9ee8b21b89ce0f8e4282c15249634a4889ca0bf0f6db89d3c2a2672fc3d74cbeR1-R4): Added a resource to create a Google Cloud Storage bucket for storing Terraform state files.
* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R1-R14): Defined variables for the project name, project ID, and region with default values.