### PR TITLE
Add module for google cloud artifact registory

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,3 +26,10 @@ resource "google_project_service" "service" {
   service            = each.value
   disable_on_destroy = false
 }
+
+module "artifact_registry" {
+  source        = "./modules/artifact_registry"
+  region        = var.region
+  repository_id = var.artifact_repo_id
+  description   = "Docker repository for TiTiler images"
+}

--- a/terraform/modules/artifact_registry/main.tf
+++ b/terraform/modules/artifact_registry/main.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "docker_repo" {
+  provider      = google-beta
+  location      = var.region
+  repository_id = var.repository_id
+  format        = "DOCKER"
+  description   = var.description
+}

--- a/terraform/modules/artifact_registry/main.tf
+++ b/terraform/modules/artifact_registry/main.tf
@@ -1,5 +1,4 @@
 resource "google_artifact_registry_repository" "docker_repo" {
-  provider      = google-beta
   location      = var.region
   repository_id = var.repository_id
   format        = "DOCKER"

--- a/terraform/modules/artifact_registry/outputs.tf
+++ b/terraform/modules/artifact_registry/outputs.tf
@@ -1,0 +1,4 @@
+output "repository_name" {
+  description = "作成されたArtifact Registryリポジトリの名前"
+  value       = google_artifact_registry_repository.docker_repo.name
+}

--- a/terraform/modules/artifact_registry/variables.tf
+++ b/terraform/modules/artifact_registry/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  type        = string
+  description = "GCPリージョン（例: us-central1）"
+}
+
+variable "repository_id" {
+  type        = string
+  description = "Artifact RegistryリポジトリのID。リポジトリ名として使われます。"
+}
+
+variable "description" {
+  type        = string
+  description = "リポジトリの説明"
+  default     = "Docker repository for storing container images."
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,3 +12,36 @@ variable "region" {
   type    = string
   default = "asia-northeast1"
 }
+
+variable "artifact_repo_id" {
+  type        = string
+  description = "Artifact RegistryリポジトリID"
+  default     = "titiler"
+}
+
+variable "frontend_bucket_name" {
+  type        = string
+  description = "フロントエンド用Cloud Storageバケット名"
+}
+
+variable "cloud_run_service_name" {
+  type        = string
+  description = "Cloud Runサービスの名前"
+}
+
+variable "titiler_image" {
+  type        = string
+  description = "Artifact Registryに格納されたTiTilerコンテナイメージのURL"
+}
+
+variable "cloud_run_max_instances" {
+  type        = number
+  description = "Cloud Runの最大インスタンス数"
+  default     = 10
+}
+
+variable "cloud_run_concurrency" {
+  type        = number
+  description = "Cloud Runの同時実行数"
+  default     = 80
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,30 +18,3 @@ variable "artifact_repo_id" {
   description = "Artifact RegistryリポジトリID"
   default     = "titiler"
 }
-
-variable "frontend_bucket_name" {
-  type        = string
-  description = "フロントエンド用Cloud Storageバケット名"
-}
-
-variable "cloud_run_service_name" {
-  type        = string
-  description = "Cloud Runサービスの名前"
-}
-
-variable "titiler_image" {
-  type        = string
-  description = "Artifact Registryに格納されたTiTilerコンテナイメージのURL"
-}
-
-variable "cloud_run_max_instances" {
-  type        = number
-  description = "Cloud Runの最大インスタンス数"
-  default     = 10
-}
-
-variable "cloud_run_concurrency" {
-  type        = number
-  description = "Cloud Runの同時実行数"
-  default     = 80
-}


### PR DESCRIPTION
This pull request introduces a new module for managing an Artifact Registry in the Terraform configuration. The changes include the addition of the module, the creation of necessary resources, and the definition of variables and outputs.

### Addition of Artifact Registry Module

* [`terraform/main.tf`](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R29-R35): Added a new module `artifact_registry` to manage the Docker repository for TiTiler images.

### Creation of Resources

* [`terraform/modules/artifact_registry/main.tf`](diffhunk://#diff-1f02dc8edabe0a4d1eee817eebbefe3ce46239d8832824c8c3874e8567da547dR1-R6): Added a new resource `google_artifact_registry_repository` to define the Docker repository with specified location, repository ID, format, and description.

### Definition of Outputs

* [`terraform/modules/artifact_registry/outputs.tf`](diffhunk://#diff-8ec3df5d35295c1586092f81248837c412fe04c060665adc03e9b24a16de5d9dR1-R4): Added an output `repository_name` to expose the name of the created Artifact Registry repository.

### Definition of Variables

* [`terraform/modules/artifact_registry/variables.tf`](diffhunk://#diff-ba74d15318f0b213f3895743487e3857a536fc6f5cb353989fbebe8c6e23dd18R1-R15): Added variables for `region`, `repository_id`, and `description` to parameterize the Artifact Registry module.
* [`terraform/variables.tf`](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R15-R20): Added a new variable `artifact_repo_id` to specify the Artifact Registry repository ID.